### PR TITLE
added Pyserial under Miscellaneous category and fixed a link

### DIFF
--- a/Machine-Learning/Sources.md
+++ b/Machine-Learning/Sources.md
@@ -32,10 +32,9 @@ Websites
 * [UCI Machine Learning Repository](http://archive.ics.uci.edu/ml/)
 * [Welcome to Deep Learning](http://deeplearning.net/)
 * [Excellent Answer by Franck-Dernoncourt](https://www.quora.com/What-are-the-best-talks-lectures-related-to-big-data-algorithms-machine-learning/answer/Franck-Dernoncourt)
-* [UCI | Machine Learning Repository] (http://archive.ics.uci.edu/ml/)
 * [Machine Learning Demos](http://mldemos.epfl.ch/)
 * [AI WEBSITES THAT DESIGN THEMSELVES](https://thegrid.io/)
-* [A Visual Introduction to Machine Learning](http://www.r2d3.us/visual-intro-to-machine-learning-part-1/http://www.kdnuggets.com/)
+* [A Visual Introduction to Machine Learning](http://www.r2d3.us/visual-intro-to-machine-learning-part-1/)
 * [Machine Learning in Games](http://satirist.org/learn-game/)
 * [Data Mining, Analytics, Big Data, and Data Science](http://www.kdnuggets.com/)
 

--- a/python/resources.md
+++ b/python/resources.md
@@ -138,7 +138,8 @@ to manipulate ISZ files (.isz), including .isz to .iso conversion
         + [jtauber](http://lanyrd.com/profile/jtauber/)@lanyrd
         + [NextDayVideo](http://www.youtube.com/user/NextDayVideo)
 + Miscellaneous
-    + [PyMite](https://wiki.python.org/moin/PyMite) Python on a microcontroller
+    + [PyMite](https://wiki.python.org/moin/PyMite) - Python on a microcontroller
+    + [Pyserial](http://pythonhosted.org/pyserial/) - Pyserial encapsulates the access for the serial port
 + Hosting
     + [Heroku](https://devcenter.heroku.com/articles/getting-started-with-python)
     + [Dotcloud](http://docs.dotcloud.com/services/python/)


### PR DESCRIPTION
this module is generally used for making serial objects and communicating with microcontroller like arduino.