### PR TITLE
Add Firecode.io to Interview questions

### DIFF
--- a/Interviews/resources.md
+++ b/Interviews/resources.md
@@ -106,6 +106,7 @@ Highly Recommended: **zouzhile's Repository** [[web][c_tb]] [[Github][c_tb_app1]
 * [Dynamic Programming](http://hawstein.com/posts/dp-novice-to-advanced.html)
 * [Interviewbit](https://www.interviewbit.com/) 
 * [CodeWars](https://www.codewars.com/)
+* [FireCode](https://www.firecode.io/)
 
 [c_tb_app1]: https://github.com/zouzhile/interview
 


### PR DESCRIPTION
Added Firecode.io website link in interview questions section under 'Interviews' resources