### PR TITLE
Add online LaTeX compilers

### DIFF
--- a/LaTeX/resources.md
+++ b/LaTeX/resources.md
@@ -17,3 +17,6 @@
  - [Letters](https://en.wikibooks.org/wiki/LaTeX/Letters)
  - [Lab/Project](https://www.overleaf.com/gallery/tagged/report)
  
+## Online LaTeX Compilers
+ - [ShareLaTeX](https://www.sharelatex.com)
+ - [Overleaf](https://www.overleaf.com)


### PR DESCRIPTION
Online compilers preclude the need for installing a compiler on your local machine. 
Effective for quick, one-time LaTeX document creation.