### PR TITLE
django/resources.md: Update must watch django videos

### DIFF
--- a/Django/resources.md
+++ b/Django/resources.md
@@ -472,7 +472,7 @@ as the NEW DJANGO BOOK.
 
 ## Videos
 
-* [Must Watch Django Videos](https://github.com/rosarior/django-must-watch/) - Must-watch videos about Django (or about Python as applied to Django)
+* [Must Watch Django Videos](https://gitlab.com/rosarior/django-must-watch) - Must-watch videos about Django (or about Python as applied to Django)
 * [GoDjango](https://godjango.com) - Django videos from basics to advanced. Covering 3rd party apps to core Django compontents.
 
 # Utilities


### PR DESCRIPTION
The link has been moved to https://gitlab.com/rosarior/django-must-watch so updating it.