### PR TITLE
adding to & alphabetizing Python conference info.

### DIFF
--- a/python/resources.md
+++ b/python/resources.md
@@ -177,9 +177,11 @@ to manipulate ISZ files (.isz), including .isz to .iso conversion
  - Spatial Data Analysis
    - [`pysal`](http://pysal.org) - PySAL (Python Spatial Analysis Library) is an open source cross-platform library for geospatial data science with an emphasis on geospatial vector data written in Python.
 ## Conference
- - [PyCon](http://pycon.org/)
- - [djangocon](http://www.djangocon.us/)
+ - [DjangoCon](http://www.djangocon.us/)
+ - [GeoPython](http://www.geopython.net)
  - [GotoConferences](http://gotocon.com/)
+ - [PyCon](http://pycon.org/)
+ - [SciPy](http://conference.scipy.org)
  - Videos
    - [PyCon US Videos - 2009, 2010, 2011](http://blip.tv/pycon-us-videos-2009-2010-2011)
    - [EuroPython Conference - 2013](https://www.youtube.com/user/PythonItalia)


### PR DESCRIPTION
 - Adding [GeoPython](http://www.geopython.net) and [SciPy](http://conference.scipy.org) to the **Conferences** section
 - Alphabetizing the **Conferences** section
 - Corrected capitalization of ~~djangocon~~ --> DjangoCon