### PR TITLE
Link no longer valid (aka, broken)

### DIFF
--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -8,7 +8,6 @@ category: Platform
 ## Resources
 * [Compilers: Principles, Techniques, and Tools](https://www.amazon.com/Compilers-Principles-Techniques-Tools-2nd/dp/0321486811)
 	- AKA *Dragon book*
-	- [Online Chapters](http://wps.aw.com/aw_aho_compilers_2/0,11227,2663889-,00.html) - Sample chapters from the second edition.
 * [Basics of Compiler Design](http://www.diku.dk/~torbenm/Basics/basics_lulu2.pdf)
 * [Compiler design in C](http://holub.com/goodies/compiler/compilerDesignInC.pdf)
 * [Let's Build a Compiler](https://compilers.iecc.com/crenshaw/)


### PR DESCRIPTION
You can click through to the eBook versions from the main Amazon link, anyway.