### PR TITLE
Add compiler resources to Compilers/resources.md

### DIFF
--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -14,7 +14,8 @@ category: Platform
 * [Compiler construction](https://www.cs.cmu.edu/~aplatzer/course/Compilers/waitegoos.pdf)
 * [Compiler Design - Basic to Advanced](https://www.youtube.com/watch?v=Qkwj65l_96I&list=PLEbnTDJUr_IcPtUXFy2b1sGRPsLFMghhS)
 * [Introduction to Compilers and Language Design](https://www3.nd.edu/~dthain/compilerbook/)
-* [Matt Might - Compilers :: CS5470](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
+* [CS5470 Compilers - Matt Might](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
+* [CS143 Compilers - Stanford Compiler Course](http://web.stanford.edu/class/archive/cs/cs143/cs143.1128/)
 
 
 ## Compilers

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -17,6 +17,7 @@ category: Platform
 * [CS5470 Compilers - Matt Might](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
 * [CS143 Compilers - Stanford Compiler Course](http://web.stanford.edu/class/archive/cs/cs143/cs143.1128/)
 * [Parsing Code - Jim Mahoney's Notes](https://cs.marlboro.college/cours/fall2019/formal_languages/notes/parsing)
+* [The man(1) of descent - Damian Conway](http://theweeks.org/xcssa/photos/files/sys-admin_V8/tpj/issues/vol3_4/tpj0304-0010.html) - Conway's explanation of Recursive Descent, a key algorithm for compiler design.
 
 
 ## Compilers

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -32,4 +32,4 @@ category: Platform
 	- [Bison](http://dinosaur.compilertools.net/bison/) - The YACC-compatible Parser Generator
 * [PLY (Python Lex-Yacc)](http://www.dabeaz.com/ply/) - PLY is an implementation of lex and yacc parsing tools for Python.
 * [SLY (Sly Lex Yacc)](https://sly.readthedocs.io/en/latest/sly.html) - SLY is a library for writing parsers and compilers with Python.
-* [mal - Make A Lisp](https://github.com/kanaka/mal) - Mal is a Clojure inspired Lisp interpreter and a learning tool for building interpreters.
+* [mal - Make A Lisp](https://github.com/kanaka/mal) - Implement Lisp in a language of your choice.

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -14,6 +14,7 @@ category: Platform
 * [Compiler construction](https://www.cs.cmu.edu/~aplatzer/course/Compilers/waitegoos.pdf)
 * [Compiler Design - Basic to Advanced](https://www.youtube.com/watch?v=Qkwj65l_96I&list=PLEbnTDJUr_IcPtUXFy2b1sGRPsLFMghhS)
 * [Introduction to Compilers and Language Design](https://www3.nd.edu/~dthain/compilerbook/)
+* [Matt Might - Compilers :: CS5470](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts on compiler design and a list of projects to learn by doing.
 
 ## Compilers
 *A list of compilers*
@@ -29,3 +30,4 @@ category: Platform
 	- [Lex](http://dinosaur.compilertools.net/lex/index.html) - A Lexical Analyzer Generator
 	- [Bison](http://dinosaur.compilertools.net/bison/) - The YACC-compatible Parser Generator
 * [PLY (Python Lex-Yacc)](http://www.dabeaz.com/ply/) - PLY is an implementation of lex and yacc parsing tools for Python.
+* [SLY (Sly Lex Yacc)](https://sly.readthedocs.io/en/latest/sly.html) - SLY is a library for writing parsers and compilers with Python.

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -14,7 +14,8 @@ category: Platform
 * [Compiler construction](https://www.cs.cmu.edu/~aplatzer/course/Compilers/waitegoos.pdf)
 * [Compiler Design - Basic to Advanced](https://www.youtube.com/watch?v=Qkwj65l_96I&list=PLEbnTDJUr_IcPtUXFy2b1sGRPsLFMghhS)
 * [Introduction to Compilers and Language Design](https://www3.nd.edu/~dthain/compilerbook/)
-* [Matt Might - Compilers :: CS5470](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts on compiler design and a list of projects to learn by doing.
+* [Matt Might - Compilers :: CS5470](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
+
 
 ## Compilers
 *A list of compilers*
@@ -31,3 +32,4 @@ category: Platform
 	- [Bison](http://dinosaur.compilertools.net/bison/) - The YACC-compatible Parser Generator
 * [PLY (Python Lex-Yacc)](http://www.dabeaz.com/ply/) - PLY is an implementation of lex and yacc parsing tools for Python.
 * [SLY (Sly Lex Yacc)](https://sly.readthedocs.io/en/latest/sly.html) - SLY is a library for writing parsers and compilers with Python.
+* [mal - Make A Lisp](https://github.com/kanaka/mal) - Mal is a Clojure inspired Lisp interpreter and a learning tool for building interpreters.

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -16,6 +16,7 @@ category: Platform
 * [Introduction to Compilers and Language Design](https://www3.nd.edu/~dthain/compilerbook/)
 * [CS5470 Compilers - Matt Might](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
 * [CS143 Compilers - Stanford Compiler Course](http://web.stanford.edu/class/archive/cs/cs143/cs143.1128/)
+* [Parsing Code - Jim Mahoney's Notes](https://cs.marlboro.college/cours/fall2019/formal_languages/notes/parsing)
 
 
 ## Compilers

--- a/Compilers/resources.md
+++ b/Compilers/resources.md
@@ -16,7 +16,7 @@ category: Platform
 * [Introduction to Compilers and Language Design](https://www3.nd.edu/~dthain/compilerbook/)
 * [CS5470 Compilers - Matt Might](http://matt.might.net/teaching/compilers/spring-2015/) - Blog posts by Prof. Matt Might on compiler design and a list of projects to learn by doing.
 * [CS143 Compilers - Stanford Compiler Course](http://web.stanford.edu/class/archive/cs/cs143/cs143.1128/)
-* [Parsing Code - Jim Mahoney's Notes](https://cs.marlboro.college/cours/fall2019/formal_languages/notes/parsing)
+* [Parsing Code - Jim Mahoney's Notes](https://cs.marlboro.college/cours/fall2019/formal_languages/notes/parsing) - Part of a Formal Languages course
 * [The man(1) of descent - Damian Conway](http://theweeks.org/xcssa/photos/files/sys-admin_V8/tpj/issues/vol3_4/tpj0304-0010.html) - Conway's explanation of Recursive Descent, a key algorithm for compiler design.
 
 


### PR DESCRIPTION
I added several compiler learning resources and compilers to the Compilers/resources.md file. All of these were useful to me when I was building [TweeTeX](https://github.com/ncreel/TweeTeX).