### PR TITLE
HTML Sololearn href fixed

### DIFF
--- a/HTML_CSS/html_resources.md
+++ b/HTML_CSS/html_resources.md
@@ -64,7 +64,7 @@ category: Languages
 * [HTML W3SCHOOL](https://www.w3schools.com/html/default.asp)
 * [CSS W3SCHOOL](https://www.w3schools.com/cssref/default.asp)
 * [HTML HTML5DOCTOR](http://www.html5doctor.com/)
-* [HTML SOLOLEARN](https://www.sololearn.com/home)
+* [HTML SOLOLEARN](https://www.sololearn.com/learning/1014)
 
 [⬆ Back to Top](#Index)
 


### PR DESCRIPTION
HTML Sololearn was pointing to the Sololearn/home, changed it to proper path