### PR TITLE
fix: update ninja build resource

### DIFF
--- a/C_plus_plus/resources.md
+++ b/C_plus_plus/resources.md
@@ -658,7 +658,7 @@ A curated list of C++ frameworks, libraries, resources, and shiny things.
 * [CMake](http://www.cmake.org/) - Cross-platform free and open-source software for managing the build process of software using a compiler-independent method. [BSD]
 * [CPM](https://github.com/iauns/cpm) - A C++ Package Manager based on CMake and Git.
 * [FASTBuild](http://www.fastbuild.org/docs/home.html) - High performance, open-source build system supporting highly scalable compilation, caching and network distribution.
-* [Ninja](http://martine.github.io/ninja/) - A small build system with a focus on speed.
+* [Ninja](https://ninja-build.org/) - A small build system with a focus on speed.
 * [Scons](http://www.scons.org/) - A software construction tool configured with Python scipt.
 * [tundra](https://github.com/deplinenoise/tundra) - High-performance code build system designed to give the best possible incremental build times even for very large software projects.
 * [tup](http://gittup.org/tup/) - File-based build system that monitors in the background for changed files.


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to the broken hyperlink leading to ninja build resource.